### PR TITLE
flake8 pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,7 @@ repos:
   rev: 5.12.0
   hooks:
   - id: isort
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
+  hooks:
+  - id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+select = E7, E9, W2, W3, W6, F
+exclude = .git,.github,.mypy_cache,__pycache__,build,dist


### PR DESCRIPTION
added tox.ini with some flake8 config (I limited the warnings to more serious stuff)
also flake8 doesn't support putting the config in pyproject.toml otherwise I would have done that.