### PR TITLE
Add basic bk-tree

### DIFF
--- a/pynear/__init__.py
+++ b/pynear/__init__.py
@@ -1,8 +1,17 @@
-# flake8: noqa
+from typing import Tuple
+
+import numpy as np
+
+from _pynear import BKTreeBinaryIndex64
+from _pynear import BKTreeBinaryIndex128
+from _pynear import BKTreeBinaryIndex256
+from _pynear import BKTreeBinaryIndex512
+from _pynear import BKTreeBinaryIndex as BKTreeBinaryIndexN
 from _pynear import VPTreeBinaryIndex64
 from _pynear import VPTreeBinaryIndex128
 from _pynear import VPTreeBinaryIndex256
 from _pynear import VPTreeBinaryIndex512
+from _pynear import VPTreeBinaryIndex as VPTreeBinaryIndexN
 from _pynear import VPTreeChebyshevIndex
 from _pynear import VPTreeL1Index
 from _pynear import VPTreeL2Index
@@ -11,11 +20,11 @@ from ._version import __version__
 
 
 class VPTreeBinaryIndex:
-    def __init__(self):
+    def __init__(self) -> None:
         self._index = None
         self._dimension = None
 
-    def set(self, data):
+    def set(self, data: np.ndarray) -> None:
         self._validate(data)
 
         dim = data.shape[1]
@@ -27,37 +36,91 @@ class VPTreeBinaryIndex:
             self._index = VPTreeBinaryIndex128()
         elif dim == 8:
             self._index = VPTreeBinaryIndex64()
+        else:
+            self._index = VPTreeBinaryIndexN()
 
         self._dimension = dim
         self._index.set(data)
 
-    def searchKNN(self, queries, k):
-        if self._index is None:
-            return [], []
-
+    def searchKNN(self, queries: np.ndarray, k: int) -> Tuple[list, list]:
         dim = queries.shape[1]
         if dim != self._dimension:
             raise ValueError(
                 f"invalid data dimension: index built data and query data dimensions must agree, index built data dimension is {dim}"
             )
 
+        if self._index is None:
+            return [], []
+
         self._validate(queries)
         return self._index.searchKNN(queries, k)
 
-    def search1NN(self, queries):
+    def search1NN(self, queries: np.ndarray) -> Tuple[list, list]:
         if self._index is None:
             return [], []
 
         self._validate(queries)
         return self._index.search1NN(queries)
 
-    def _validate(self, input):
-        if len(input.shape) != 2:
+    def _validate(self, data: np.ndarray) -> None:
+        if len(data.shape) != 2:
             raise ValueError("invalid data shape: binary indexes must be 2D")
 
-        if input.dtype != "uint8":
+        if data.dtype != "uint8":
             raise TypeError("invalid data type: binary indexes must be uint8")
 
-        dim = input.shape[1]
-        if dim not in [8, 16, 32, 64]:
-            raise ValueError("invalid dimension: binary indexes must be 8, 16, 32 or 64 bytes")
+
+class BKTreeBinaryIndex:
+    def __init__(self) -> None:
+        self._index = None
+        self._dimension = None
+
+    def set(self, data: np.ndarray) -> None:
+        self._validate(data)
+
+        dim = data.shape[1]
+        if dim == 64:
+            self._index = BKTreeBinaryIndex512()
+        elif dim == 32:
+            self._index = BKTreeBinaryIndex256()
+        elif dim == 16:
+            self._index = BKTreeBinaryIndex128()
+        elif dim == 8:
+            self._index = BKTreeBinaryIndex64()
+        else:
+            self._index = BKTreeBinaryIndexN()
+
+        self._dimension = dim
+        self._index.set(data)
+
+    def find_threshold(self, queries: np.ndarray, threshold: int) -> Tuple[list, list]:
+        dim = queries.shape[1]
+        if dim != self._dimension:
+            raise ValueError(
+                f"invalid data dimension: index built data and query data dimensions must agree, index built data dimension is {dim}"
+            )
+
+        if self._index is None:
+            return [], []
+
+        self._validate(queries)
+        return self._index.find_threshold(queries, threshold)
+
+    def empty(self) -> bool:
+        if self._index is None:
+            return True
+
+        return self._index.empty()
+
+    def values(self) -> list:
+        if self._index is None:
+            return []
+
+        return self._index.values()
+
+    def _validate(self, data: np.ndarray) -> None:
+        if len(data.shape) != 2:
+            raise ValueError("invalid data shape: binary indexes must be 2D")
+
+        if data.dtype != "uint8":
+            raise TypeError("invalid data type: binary indexes must be uint8")

--- a/pynear/include/BKTree.hpp
+++ b/pynear/include/BKTree.hpp
@@ -1,0 +1,156 @@
+#include <deque>
+#include <map>
+#include <optional>
+
+template <typename key_t, typename distance_t> class Metric {
+    public:
+    static distance_t distance(const key_t &a, const key_t &b);
+    static std::optional<distance_t> threshold_distance(const key_t &a, const key_t &b, distance_t threshold);
+};
+
+template <typename key_t, typename distance_t> class BKNode {
+    public:
+    key_t key;
+    std::map<distance_t, BKNode<key_t, distance_t> *> leaves;
+    std::optional<distance_t> max_distance;
+
+    BKNode(key_t key) : key(key) {}
+
+    void add_leaf(distance_t distance, key_t key) {
+        leaves[distance] = new BKNode<key_t, distance_t>(key);
+        max_distance = std::max<distance_t>(distance, max_distance.value_or(0));
+    }
+
+    void clear() {
+        for (auto const &[d, bknode] : leaves) {
+            delete bknode;
+        }
+        leaves.clear();
+    }
+
+    virtual ~BKNode() { clear(); }
+};
+
+template <typename key_t, typename distance_t, typename metric> class BKTree {
+    BKNode<key_t, distance_t> *root;
+
+    public:
+    BKTree() : root(nullptr) {}
+
+    bool add(key_t key) {
+        if (root == nullptr) {
+            root = new BKNode<key_t, distance_t>(key);
+        } else {
+            BKNode<key_t, distance_t> *node = root;
+            distance_t dist;
+
+            while (true) {
+                dist = metric::distance(node->key, key);
+                auto next_it = node->leaves.find(dist);
+                if (next_it == node->leaves.end() || dist == 0) {
+                    break;
+                }
+                node = next_it->second;
+            }
+
+            if (dist > 0) {
+                node->add_leaf(dist, key);
+            } else {
+                return false; // didn't insert key
+            }
+        }
+        return true; // inserted new key
+    }
+
+    void update(std::vector<key_t> keys) {
+        for (auto const &key : keys) {
+            add(key);
+        }
+    }
+
+    std::tuple<std::vector<distance_t>, std::vector<key_t>> find(key_t key, distance_t threshold) {
+        static_assert(std::is_signed<distance_t>::value, "Arithmetic required signed distances");
+
+        BKNode<key_t, distance_t> *node = root;
+        std::vector<distance_t> distances;
+        std::vector<key_t> keys;
+
+        if (node == nullptr) {
+            return std::make_tuple(distances, keys);
+        }
+
+        std::deque<BKNode<key_t, distance_t> *> candidates = {node};
+        distance_t distance_cutoff, dist, lower, upper;
+        BKNode<key_t, distance_t> *candidate;
+        std::optional<distance_t> dist_opt;
+
+        while (!candidates.empty()) {
+            candidate = candidates.front();
+            candidates.pop_front();
+            distance_cutoff = candidate->max_distance.value_or(0) + threshold;
+            dist_opt = metric::threshold_distance(key, candidate->key, distance_cutoff);
+
+            if (!dist_opt.has_value()) {
+                continue;
+            }
+
+            dist = dist_opt.value();
+
+            if (dist <= threshold) {
+                distances.push_back(dist);
+                keys.push_back(candidate->key);
+            }
+
+            lower = dist - threshold;
+            upper = dist + threshold;
+            for (auto const &[d, bknode] : candidate->leaves) {
+                if (lower <= d && d <= upper) {
+                    candidates.push_back(bknode);
+                }
+            }
+        }
+        return std::make_tuple(distances, keys);
+    }
+
+    std::tuple<std::vector<std::vector<distance_t>>, std::vector<std::vector<key_t>>> find_batch(const std::vector<key_t> &keys,
+                                                                                                 distance_t threshold) {
+        std::vector<std::vector<distance_t>> distances_out;
+        std::vector<std::vector<key_t>> keys_out;
+
+        for (auto const &key : keys) {
+            auto const &[distances_res, keys_res] = find(key, threshold);
+            distances_out.push_back(std::move(distances_res));
+            keys_out.push_back(std::move(keys_res));
+        }
+
+        return std::make_tuple(distances_out, keys_out);
+    }
+
+    bool empty() { return root == nullptr; }
+
+    static void _values(BKNode<key_t, distance_t> *node, std::vector<key_t> &out) {
+        out.push_back(node->key);
+
+        for (auto [d, bknode] : node->leaves) {
+            _values(bknode, out);
+        }
+    }
+
+    std::vector<key_t> values() {
+        std::vector<key_t> out;
+
+        if (root != nullptr) {
+            _values(root, out);
+        }
+        return out;
+    }
+
+    void clear() {
+        if (root != nullptr) {
+            delete root;
+        }
+        root = nullptr;
+    }
+
+    virtual ~BKTree() { clear(); }
+};

--- a/pynear/tests/test_bktree.py
+++ b/pynear/tests/test_bktree.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+import pynear
+
+CLASSES = [
+    (pynear.BKTreeBinaryIndex64, 8),
+    (pynear.BKTreeBinaryIndex128, 16),
+    (pynear.BKTreeBinaryIndex256, 32),
+    (pynear.BKTreeBinaryIndex512, 64),
+    (pynear.BKTreeBinaryIndexN, 1),
+]
+
+
+def hamming_distance_pairwise(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    r = (1 << np.arange(8))[:, None, None, None]
+    return np.count_nonzero((np.bitwise_xor(a[:, None, :], b[None, :, :]) & r) != 0, axis=(0, -1))
+
+
+@pytest.mark.parametrize("bktree_cls, dimensions", CLASSES)
+def test_bktree_empty_index(bktree_cls, dimensions):
+    num_points = 2
+    data = np.random.randint(0, 255, size=(num_points, dimensions), dtype=np.uint8)
+    empty = np.array([], dtype=np.uint8)
+
+    tree = bktree_cls()
+    distances, keys = tree.find_threshold(data, 1)
+    truth = [[]] * num_points
+    assert truth == distances
+
+    tree.set(empty)
+    distances, keys = tree.find_threshold(data, 1)
+    truth = [[]] * num_points
+    assert truth == distances
+
+
+@pytest.mark.parametrize("bktree_cls, dimensions", CLASSES)
+def test_bktree_find_self(bktree_cls, dimensions):
+    num_points = 2
+    data = np.random.randint(0, 255, size=(num_points, dimensions), dtype=np.uint8)
+
+    tree = bktree_cls()
+    tree.set(data)
+    distances, keys = tree.find_threshold(data, 0)
+    assert distances == [[0]] * num_points
+    assert keys == data[:, None, :].tolist()
+
+
+@pytest.mark.parametrize("bktree_cls, dimensions", CLASSES)
+def test_bktree_find_all(bktree_cls, dimensions):
+    num_points = 2
+    data = np.random.randint(0, 255, size=(num_points, dimensions), dtype=np.uint8)
+
+    tree = bktree_cls()
+    tree.set(data)
+    distances, keys = tree.find_threshold(data, 255)
+
+    assert distances == hamming_distance_pairwise(data, data).tolist()
+    assert keys == np.broadcast_to(data, (num_points, num_points, dimensions)).tolist()

--- a/tox.ini
+++ b/tox.ini
@@ -2,3 +2,5 @@
 max-line-length = 120
 select = E7, E9, W2, W3, W6, F
 exclude = .git,.github,.mypy_cache,__pycache__,build,dist
+per-file-ignores =
+    __init__.py: F401


### PR DESCRIPTION
it compiles, but it's not tested much right now

- there are two different metric functions since a common use case for bktrees is to use Levenshtein metric which can be shortcut if you don't need larger distances
- right now it returns vectors, not indices

todo
- [x] destructor implemented
- [x] range search
- [ ] top-k neighbours search
- [x] 64-bit hamming distance
- [x] generic hamming distance