### PR TITLE
OpenMP support to bk-tree find_batch

### DIFF
--- a/pynear/include/VPTree.hpp
+++ b/pynear/include/VPTree.hpp
@@ -22,8 +22,6 @@
 #include "ISerializable.hpp"
 #include "VPLevelPartition.hpp"
 
-#define ENABLE_OMP_PARALLEL 1
-
 namespace vptree {
 
 template <typename T, typename distance_type, distance_type (*distance)(const T &, const T &)> class VPTree : public ISerializable {

--- a/pynear/tests/CMakeLists.txt
+++ b/pynear/tests/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.10)
 include(GoogleTest)
 find_package(OpenMP)
 
+add_compile_definitions(ENABLE_OMP_PARALLEL=1)
+
 # Download and unpack googletest at configure time
 configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ ext_modules = [
         cxx_std=17,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
+        define_macros=[("ENABLE_OMP_PARALLEL", "1")],
     ),
 ]
 


### PR DESCRIPTION
move ENABLE_OMP_PARALLEL define to setup.py

@pablocael do we need to add the macro definition somewhere for the cpp tests?