### PR TITLE
Only use openmp if batch size > 1

### DIFF
--- a/pynear/include/BKTree.hpp
+++ b/pynear/include/BKTree.hpp
@@ -121,7 +121,7 @@ template <typename key_t, typename distance_t, typename metric> class BKTree {
         std::vector<std::vector<key_t>> keys_out(keys.size());
 
 #if (ENABLE_OMP_PARALLEL)
-#pragma omp parallel for schedule(static, 1)
+#pragma omp parallel for schedule(static, 1) if (keys.size() > 1)
 #endif
         // i should be size_t, however msvc requires signed integral loop variables (except with -openmp:llvm)
         for (int i = 0; i < static_cast<int>(keys.size()); ++i) {

--- a/pynear/include/VPTree.hpp
+++ b/pynear/include/VPTree.hpp
@@ -185,10 +185,10 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         results.resize(queries.size());
 
 #if (ENABLE_OMP_PARALLEL)
-#pragma omp parallel for schedule(static, 1)
+#pragma omp parallel for schedule(static, 1) if (queries.size() > 1)
 #endif
         // i should be size_t, however msvc requires signed integral loop variables (except with -openmp:llvm)
-        for (int i = 0; i < queries.size(); ++i) {
+        for (int i = 0; i < static_cast<int>(queries.size()); ++i) {
             const T &query = queries[i];
             std::priority_queue<VPTreeSearchElement> knnQueue;
             searchKNN(_rootPartition, query, k, knnQueue);
@@ -212,10 +212,10 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         distances.resize(queries.size());
 
 #if (ENABLE_OMP_PARALLEL)
-#pragma omp parallel for schedule(static, 1)
+#pragma omp parallel for schedule(static, 1) if (queries.size() > 1)
 #endif
         // i should be size_t, see above
-        for (int i = 0; i < queries.size(); ++i) {
+        for (int i = 0; i < static_cast<int>(queries.size()); ++i) {
             const T &query = queries[i];
             distance_type dist = 0;
             int64_t index = -1;


### PR DESCRIPTION
For the bk-tree this double the performance if only looking up a single vector. I haven't benchmarked the vptree, but there should either be a speedup as well or at least no negetive impact.

The if basically only enables openmp for loops > 1. For small batchsizes like 2-3 there might still a negative impact of using openmp. But it would depend on the tree size I guess, for big trees there might be a benefit even looking up just two vectors in parallel.

The cast is just to fix a compiler warning.