### PR TITLE
update cibuildwheel to 2.16.5 to fix windows build issue

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: pypa/cibuildwheel@v2.12.3
+    - uses: pypa/cibuildwheel@v2.16.5
       env:
         # skip pypy 3.7 and 3.8 as numpy does not support it
         CIBW_SKIP: cp36-* pp37-* pp38-*


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/issues/1740