### PR TITLE
Skip all pypy builds

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: pypa/cibuildwheel@v2.16.5
       env:
-        # skip pypy 3.7 and 3.8 as numpy does not support it
-        CIBW_SKIP: cp36-* pp37-* pp38-*
+        # skip pypy 3.10 as numpy does not support it
+        CIBW_SKIP: cp36-* pp310-*
         CIBW_ARCHS: auto64
         CIBW_BEFORE_ALL_MACOS: brew install llvm libomp
         CIBW_ENVIRONMENT_MACOS: CC="clang" CXX="clang++" PATH="/usr/local/opt/llvm/bin:$PATH" LDFLAGS="-L/usr/local/opt/llvm/lib" CPPFLAGS="-I/usr/local/opt/llvm/include"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,11 +18,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: pypa/cibuildwheel@v2.16.5
       env:
-        # skip pypy 3.10 as numpy does not support it
-        CIBW_SKIP: cp36-* pp310-*
+        # skip pypy as numpy does not support it well
+        CIBW_SKIP: cp36-* pp*
         CIBW_ARCHS: auto64
         CIBW_BEFORE_ALL_MACOS: brew install llvm libomp
         CIBW_ENVIRONMENT_MACOS: CC="clang" CXX="clang++" PATH="/usr/local/opt/llvm/bin:$PATH" LDFLAGS="-L/usr/local/opt/llvm/lib" CPPFLAGS="-I/usr/local/opt/llvm/include"
@@ -36,7 +36,7 @@ jobs:
     needs: build-wheels
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8


### PR DESCRIPTION
pp37-pp39 have numpy wheels available, the tests still fail with weird reasons. For example `ImportError: cannot import name 'default_rng'`
pp310 doesn't have numpy wheels available yet.