### PR TITLE
Use v4 of github artifacts action

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,8 +28,9 @@ jobs:
         CIBW_ENVIRONMENT_MACOS: CC="clang" CXX="clang++" PATH="/usr/local/opt/llvm/bin:$PATH" LDFLAGS="-L/usr/local/opt/llvm/lib" CPPFLAGS="-I/usr/local/opt/llvm/include"
         CIBW_BEFORE_BUILD_MACOS: clang --version
         CIBW_BUILD_VERBOSITY: 1
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
 
   build-sdist:
@@ -44,8 +45,9 @@ jobs:
       run: |
         python -m pip install build
         python -m build --sdist
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
+        name: sdist
         path: ./dist/*.tar.gz
 
   upload-pypi:
@@ -55,8 +57,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: artifact
         path: dist
+        merge-multiple: true
     - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Deprecation notice: v1, v2, and v3 of the artifact actions
https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/